### PR TITLE
Use ExcelDataReader and deprecate OleDb

### DIFF
--- a/SODA.Utilities.Tests/ExcelDataReaderHelperTests.cs
+++ b/SODA.Utilities.Tests/ExcelDataReaderHelperTests.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Data;
+using System.IO;
+using System.Linq;
+using Microsoft.Win32;
+using NUnit.Framework;
+using SODA.Utilities.Tests.Mocks;
+using Excel;
+
+namespace SODA.Utilities.Tests
+{
+    [TestFixture]
+    public class ExcelDataReaderHelperTests
+    {
+        [Test]
+        [Category("ExcelDataReaderHelper")]
+        public void MakeConnection_With_Empty_Filename_Throws_Exception()
+        {
+            string nullInput = null;
+            string emptyInput = String.Empty;
+
+            Assert.That(
+                () => ExcelDataReaderHelper.MakeExcelReader(nullInput),
+                Throws.ArgumentException
+            );
+
+            Assert.That(
+                () => ExcelDataReaderHelper.MakeExcelReader(emptyInput),
+                Throws.ArgumentException
+            );
+        }
+
+        [TestCase("something.txt")]
+        [TestCase("something_xls")]
+        [TestCase("something_xlsx")]
+        [TestCase("something.xls.txt")]
+        [TestCase("something.xlsx.txt")]
+        [Category("ExcelDataReaderHelper")]
+        public void MakeReader_With_NonExcel_Filename_Throws_ArgumentException(string nonExcelFileName)
+        {
+            Assert.That(
+                () => ExcelDataReaderHelper.MakeExcelReader(nonExcelFileName),
+                Throws.ArgumentException
+            );
+        }
+
+        [TestCase("not-there.xls")]
+        [TestCase("not-there.xlsx")]
+        [Category("ExcelDataReaderHelper")]
+        public void MakeConnection_With_NonExistent_Excel_File_Throws_FileNotFoundException(string nonExistentExcelFileName)
+        {
+            Assert.That(
+                () => ExcelDataReaderHelper.MakeExcelReader(nonExistentExcelFileName),
+                Throws.InstanceOf<FileNotFoundException>()
+            );
+        }
+
+        [Test]
+        [TestCaseSource(typeof(FileMocks), "ExcelMocks")]
+        [Category("ExcelDataReaderHelper")]
+        public void MakeConnection_With_Valid_Excel_Filename_Returns_IExcelDataReader(string excelFileName)
+        {
+            IExcelDataReader reader = null;
+
+            Assert.That(
+                () => reader = ExcelDataReaderHelper.MakeExcelReader(excelFileName),
+                Throws.Nothing
+            );
+
+            Assert.NotNull(reader);
+            Assert.IsTrue(reader.IsValid);
+        }
+
+        [Test]
+        [Category("ExcelDataReaderHelper")]
+        public void GetRowsFromDataSheets_With_Null_Connection_Throws_ArgumentNullException()
+        {
+            IExcelDataReader nullConnection = null;
+
+            Assert.That(
+                () => ExcelDataReaderHelper.GetRowsFromDataSheets(nullConnection),
+                Throws.InstanceOf<ArgumentNullException>()
+            );
+        }
+
+        [Test]
+        [TestCaseSource(typeof(FileMocks), "ExcelMocks")]
+        [Category("ExcelDataReaderHelper")]
+        public void GetRowsFromDataSheets_Close_The_Connection(string excelFileName)
+        {
+            IExcelDataReader reader = ExcelDataReaderHelper.MakeExcelReader(excelFileName);
+
+            reader.Close();
+
+            Assert.IsTrue(reader.IsClosed);
+            Assert.That(
+                () => ExcelDataReaderHelper.GetRowsFromDataSheets(reader),
+                Throws.InstanceOf<ArgumentException>()
+            );
+        }
+
+        [Test]
+        [TestCaseSource(typeof(FileMocks), "ExcelMocks")]
+        [Category("ExcelDataReaderHelper")]
+        public void GetRowsFromDataSheets_Gets_All_Rows_From_All_Data_Sheets(string excelFileName)
+        {
+            IExcelDataReader reader = ExcelDataReaderHelper.MakeExcelReader(excelFileName);
+
+            var rows = ExcelDataReaderHelper.GetRowsFromDataSheets(reader);
+
+            Assert.AreEqual(3, rows.Count());
+
+            for (int i = 0; i < rows.Count(); i++)
+            {
+                Assert.AreEqual(String.Format("baz{0}", i + 1), rows.ElementAt(i)["foo"]);
+                Assert.AreEqual(String.Format("qux{0}", i + 1), rows.ElementAt(i)["bar"]);
+            }
+        }
+    }
+}

--- a/SODA.Utilities.Tests/ExcelOleDbHelperTests.cs
+++ b/SODA.Utilities.Tests/ExcelOleDbHelperTests.cs
@@ -127,6 +127,7 @@ namespace SODA.Utilities.Tests
         }
 
         [Test]
+        [Ignore("Unique OleDB registry hack and is not part of the SODA.NET project")]
         [Category("ExcelOleDbHelper")]
         public void System_Has_TypeGuessRows_Registry_Setting_To_Maximum_Value()
         {

--- a/SODA.Utilities.Tests/SODA.Utilities.Tests.csproj
+++ b/SODA.Utilities.Tests/SODA.Utilities.Tests.csproj
@@ -43,6 +43,12 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Excel">
+      <HintPath>..\packages\ExcelDataReader.2.1.2.3\lib\net45\Excel.dll</HintPath>
+    </Reference>
+    <Reference Include="ICSharpCode.SharpZipLib">
+      <HintPath>..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Exchange.WebServices, Version=15.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
       <HintPath>..\packages\EWS-Api-2.1.1.0.0\lib\net35\Microsoft.Exchange.WebServices.dll</HintPath>
@@ -75,6 +81,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="DataRowExtensionsTests.cs" />
+    <Compile Include="ExcelDataReaderHelperTests.cs" />
     <Compile Include="ExcelOleDbHelperTests.cs" />
     <Compile Include="FileLoggingTests.cs" />
     <Compile Include="Mocks\DataRowMocks.cs" />

--- a/SODA.Utilities.Tests/packages.config
+++ b/SODA.Utilities.Tests/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="EWS-Api-2.1" version="1.0.0" targetFramework="net45" />
+  <package id="ExcelDataReader" version="2.1.2.3" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />
 </packages>

--- a/SODA.Utilities/ExcelDataReaderHelper.cs
+++ b/SODA.Utilities/ExcelDataReaderHelper.cs
@@ -44,7 +44,7 @@ namespace SODA.Utilities
         }
 
         /// <summary>
-        /// Opens the specified OleDbConnection, collects all data rows in every sheet in the underlying Excel file, and then closes the connection.
+        /// Uses the specified IExcelDataReader object, collects all data rows in every sheet in the underlying Excel file, and then closes the connection.
         /// </summary>
         /// <param name="reader">An IExcelDataReader object to an Excel file with at least one sheet of data.</param>
         /// <param name="isFirstRowColumnNames">Whether or not the first row  of a worksheet is the name of the column; if is, we won't add it in the returned IEnumerable</param>

--- a/SODA.Utilities/ExcelDataReaderHelper.cs
+++ b/SODA.Utilities/ExcelDataReaderHelper.cs
@@ -1,0 +1,78 @@
+﻿using Excel;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SODA.Utilities
+{
+    /// <summary>
+    /// A helper class for working with Excel using ExcelDataReader
+    /// </summary>
+    public class ExcelDataReaderHelper
+    {
+        /// <summary>
+        /// Creates an IExcelDataReader object from a specified Excel file.
+        /// </summary>
+        /// <param name="excelFileName">The path to a readable Excel (.xls or .xlsx) file.</param>
+        /// <returns>An IExcelDataReader to the specified Excel file.</returns>
+        public static IExcelDataReader MakeExcelReader (string excelFileName)
+        {
+            if (!String.IsNullOrEmpty(excelFileName) && (excelFileName.EndsWith(".xls") || excelFileName.EndsWith(".xlsx")))
+            {
+                if (File.Exists(excelFileName))
+                {
+                    FileStream stream = File.Open(excelFileName, FileMode.Open, FileAccess.Read);
+
+                    if (excelFileName.EndsWith(".xls"))
+                    {
+                        return ExcelReaderFactory.CreateBinaryReader(stream);
+                    }
+                    else
+                    {
+                        return ExcelReaderFactory.CreateOpenXmlReader(stream);
+                    }
+                }
+
+                throw new FileNotFoundException("The specified file does not exist.", excelFileName);
+            }
+
+            throw new ArgumentException("Not a valid Excel (.xls or .xlsx) file.", "excelFileName");
+        }
+
+        /// <summary>
+        /// Opens the specified OleDbConnection, collects all data rows in every sheet in the underlying Excel file, and then closes the connection.
+        /// </summary>
+        /// <param name="reader">An IExcelDataReader object to an Excel file with at least one sheet of data.</param>
+        /// <param name="isFirstRowColumnNames">Whether or not the first row  of a worksheet is the name of the column; if is, we won't add it in the returned IEnumerable</param>
+        /// <returns>The combined collection of rows from each sheet of data in the underlying Excel file.</returns>
+        public static IEnumerable<DataRow> GetRowsFromDataSheets (IExcelDataReader reader, bool isFirstRowColumnNames = true)
+        {
+            if (reader == null)
+            {
+                throw new ArgumentNullException("Must provide a valid IExcelDataReader object.", "reader");
+            }
+
+            if (!reader.IsValid || reader.IsClosed)
+            {
+                throw new ArgumentException("Must provide a valid and open IExcelDataReader object.", "reader");
+            }
+
+            reader.IsFirstRowAsColumnNames = isFirstRowColumnNames;
+
+            var allDataRows = new List<DataRow>();
+
+            foreach (DataTable table in reader.AsDataSet().Tables)
+            {
+                allDataRows.AddRange(table.Rows.OfType<DataRow>());
+            }
+
+            reader.Close();
+
+            return allDataRows;
+        }
+    }
+}

--- a/SODA.Utilities/ExcelOleDbHelper.cs
+++ b/SODA.Utilities/ExcelOleDbHelper.cs
@@ -9,13 +9,15 @@ namespace SODA.Utilities
     /// <summary>
     /// A helper class for working with Excel over OleDb.
     /// </summary>
+    [Obsolete("Usage of OleDb will be removed in v0.4.0. Use the ExcelDataReaderHelper class instead.")]
     public class ExcelOleDbHelper
     {
-        /// <summary>
+        /// <deprecated type="deprecate">
         /// Creates an OleDbConnection to a specified Excel file.
-        /// </summary>
+        /// </deprecated>
         /// <param name="excelFileName">The path to a readable Excel (.xls or .xlsx) file.</param>
         /// <returns>An OleDbConnection to the specified Excel file.</returns>
+        [Obsolete("This method will be removed in v0.4.0. Use ExcelDataReaderHelper::MakeExcelReader() instead.")]
         public static OleDbConnection MakeConnection(string excelFileName)
         {
             if (!String.IsNullOrEmpty(excelFileName) && (excelFileName.EndsWith(".xls") || excelFileName.EndsWith(".xlsx")))
@@ -35,11 +37,12 @@ namespace SODA.Utilities
             throw new ArgumentException("Not a valid Excel (.xls or .xlsx) file.", "excelFileName");
         }
 
-        /// <summary>
+        /// <deprecated type="deprecate">
         /// Opens the specified OleDbConnection, collects all data rows in every sheet in the underlying Excel file, and then closes the connection.
-        /// </summary>
+        /// </deprecated>
         /// <param name="connection">An OleDbConnection to an Excel file with at least one sheet of data.</param>
         /// <returns>The combined collection of rows from each sheet of data in the underlying Excel file.</returns>
+        [Obsolete("This method will be removed in v0.4.0. Use ExcelDataReaderHelper::GetRowsFromDataSheets() instead.")]
         public static IEnumerable<DataRow> GetRowsFromDataSheets(OleDbConnection connection)
         {
             if (connection == null)

--- a/SODA.Utilities/SODA.Utilities.csproj
+++ b/SODA.Utilities/SODA.Utilities.csproj
@@ -40,6 +40,12 @@
     <DocumentationFile>bin\Release\SODA.Utilities.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Excel">
+      <HintPath>..\packages\ExcelDataReader.2.1.2.3\lib\net45\Excel.dll</HintPath>
+    </Reference>
+    <Reference Include="ICSharpCode.SharpZipLib">
+      <HintPath>..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Exchange.WebServices">
       <HintPath>..\packages\EWS-Api-2.1.1.0.0\lib\net35\Microsoft.Exchange.WebServices.dll</HintPath>
     </Reference>
@@ -61,6 +67,7 @@
     </Compile>
     <Compile Include="DataFileExporter.cs" />
     <Compile Include="Ews2007Sp1Client.cs" />
+    <Compile Include="ExcelDataReaderHelper.cs" />
     <Compile Include="ExcelOleDbHelper.cs" />
     <Compile Include="EwsClient.cs">
       <SubType>Code</SubType>

--- a/SODA.Utilities/packages.config
+++ b/SODA.Utilities/packages.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="EWS-Api-2.1" version="1.0.0" targetFramework="net45" />
+  <package id="ExcelDataReader" version="2.1.2.3" targetFramework="net45" />
+  <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Using Microsoft's OleDb library requires installation the Access Database Engine and this might not always be a possibility, so instead there's a NuGet package available that has similar functionality, [ExcelDataReader](https://github.com/ExcelDataReader/ExcelDataReader).

I've added unit tests that were based off the existing OleDbHelper tests and have ported the two static functions to be part of ExcelDataReader. I've also added deprecation notices and messages that OleDb support will be dropped in v0.4.0.