### PR TITLE
Update README about app tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ A [Socrata Open Data API](http://dev.socrata.com) (SODA) client library targetin
 Simple, read-only access
 
 ```c#
-var client = new SodaClient("data.smgov.net", "AppToken");
+//initialize a new client
+//make sure you register for your own app token (http://dev.socrata.com/register) and replace the one below
+var client = new SodaClient("data.smgov.net", "REPLACE_ME_WITH_YOUR_APP_TOKEN");
 
 //read metadata of a dataset using the resource identifier (Socrata 4x4)
 var metadata = client.GetMetadata("1234-wxyz");


### PR DESCRIPTION
I had a developer drop by our IRC channel today who had an issue getting the client to work, and it turned out it was because it was unclear that he needed to register for his own app token.

This commit just makes that more specific.