### PR TITLE
Fixes #39: Limit updated to 50K

### DIFF
--- a/SODA.Tests/SoqlQueryTests.cs
+++ b/SODA.Tests/SoqlQueryTests.cs
@@ -354,8 +354,8 @@ namespace SODA.Tests
             var soql = new SoqlQuery().Limit(limit);
         }
 
-        [TestCase(1001)]
-        [TestCase(9999)]
+        [TestCase(50001)]
+        [TestCase(59999)]
         [Category("SoqlQuery")]
         public void Limit_Clause_Has_A_Ceiling_At_MaximumLimit(int limit)
         {

--- a/SODA/SoqlQuery.cs
+++ b/SODA/SoqlQuery.cs
@@ -80,9 +80,9 @@ namespace SODA
         /// The maximum number of results a query may return.
         /// </summary>
         /// <remarks>
-        /// The maximum that can be requested with limit is 1000 (http://dev.socrata.com/docs/queries.html#the_limit_parameter)
+        /// The maximum that can be requested with limit is 50,000 (http://dev.socrata.com/docs/paging.html)
         /// </remarks>
-        public static readonly int MaximumLimit = 1000;
+        public static readonly int MaximumLimit = 50000;
 
         /// <summary>
         /// Gets the columns that this SoqlQuery will select.


### PR DESCRIPTION
Discovered by a dev [on Stack Overflow](https://stackoverflow.com/questions/30569398/fetching-50000-records-at-time-using-soql?noredirect=1#comment49254118_30569398)