### PR TITLE
Disabling unsupported security protocols

### DIFF
--- a/SODA.Tests/SodaRequestTests.cs
+++ b/SODA.Tests/SodaRequestTests.cs
@@ -21,6 +21,16 @@ namespace SODA.Tests
 
         [Test]
         [Category("SodaRequest")]
+        public void New_Disables_Unsupported_Protocols()
+        {
+            var request = new SodaRequest(exampleUri, "GET", null, null, null);
+
+            Assert.False((ServicePointManager.SecurityProtocol & SecurityProtocolType.Ssl3) == SecurityProtocolType.Ssl3);
+            Assert.False((ServicePointManager.SecurityProtocol & SecurityProtocolType.Tls) == SecurityProtocolType.Tls);
+        }
+
+        [Test]
+        [Category("SodaRequest")]
         public void New_Returns_Request_With_Specified_Uri()
         {
             var request = new SodaRequest(exampleUri, "GET", null, null, null);

--- a/SODA.Tests/SodaRequestTests.cs
+++ b/SODA.Tests/SodaRequestTests.cs
@@ -31,6 +31,29 @@ namespace SODA.Tests
 
         [Test]
         [Category("SodaRequest")]
+        public void New_Enables_Minimum_Protocol()
+        {
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Ssl3 | SecurityProtocolType.Tls;
+
+            var request = new SodaRequest(exampleUri, "GET", null, null, null);
+
+            Assert.True((ServicePointManager.SecurityProtocol & SecurityProtocolType.Tls11) == SecurityProtocolType.Tls11);
+        }
+
+        [Test]
+        [Category("SodaRequest")]
+        public void New_Maintains_Higher_Protocol()
+        {
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
+            var request = new SodaRequest(exampleUri, "GET", null, null, null);
+
+            Assert.False((ServicePointManager.SecurityProtocol & SecurityProtocolType.Tls11) == SecurityProtocolType.Tls11);
+            Assert.True((ServicePointManager.SecurityProtocol & SecurityProtocolType.Tls12) == SecurityProtocolType.Tls12);
+        }
+
+        [Test]
+        [Category("SodaRequest")]
         public void New_Returns_Request_With_Specified_Uri()
         {
             var request = new SodaRequest(exampleUri, "GET", null, null, null);

--- a/SODA/SodaRequest.cs
+++ b/SODA/SodaRequest.cs
@@ -163,5 +163,15 @@ namespace SODA
 
             return result;
         }
+
+        /// <summary>
+        /// Disable unsupported security protocols for all requests.
+        /// See https://support.socrata.com/hc/en-us/articles/235267087 for more information.
+        /// </summary>
+        static SodaRequest()
+        {
+            System.Net.ServicePointManager.SecurityProtocol &= ~SecurityProtocolType.Ssl3;
+            System.Net.ServicePointManager.SecurityProtocol &= ~SecurityProtocolType.Tls;
+        }
     }
 }

--- a/SODA/SodaRequest.cs
+++ b/SODA/SodaRequest.cs
@@ -34,6 +34,7 @@ namespace SODA
         /// <param name="payload">The body of the request.</param>
         /// <param name="timeout">The number of milliseconds to wait for a response before throwing a Timeout WebException.</param>
         internal SodaRequest(Uri uri, string method, string appToken, string username, string password, SodaDataFormat dataFormat = SodaDataFormat.JSON, string payload = null, int? timeout = null)
+            : this()
         {
             this.dataFormat = dataFormat;
 
@@ -168,7 +169,7 @@ namespace SODA
         /// Disable unsupported security protocols for all requests.
         /// See https://support.socrata.com/hc/en-us/articles/235267087 for more information.
         /// </summary>
-        static SodaRequest()
+        private SodaRequest()
         {
             System.Net.ServicePointManager.SecurityProtocol &= ~SecurityProtocolType.Ssl3;
             System.Net.ServicePointManager.SecurityProtocol &= ~SecurityProtocolType.Tls;

--- a/SODA/SodaRequest.cs
+++ b/SODA/SodaRequest.cs
@@ -172,6 +172,8 @@ namespace SODA
         {
             System.Net.ServicePointManager.SecurityProtocol &= ~SecurityProtocolType.Ssl3;
             System.Net.ServicePointManager.SecurityProtocol &= ~SecurityProtocolType.Tls;
+            if (System.Net.ServicePointManager.SecurityProtocol == 0)
+                System.Net.ServicePointManager.SecurityProtocol = System.Net.SecurityProtocolType.Tls11;
         }
     }
 }


### PR DESCRIPTION
Disable SSL 3 and TLS 1.0 for all outbound requests, as per https://support.socrata.com/hc/en-us/articles/235267087 