### PR TITLE
add note and documentation on different APIs for writing to socrata datasets to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ IEnumerable<MyClass> payload = GetPayloadData();
 client.Upsert(payload, "1234-wxyz");
 ```
 
+Note: This library supports writing directly to datasets with the Socrata Open Data API. For write operations that use 
+data transformations in the Socrata Data Management Experience (the user interface for creating datasets), use the Socrata 
+Data Management API. For more details on when to use SODA vs the Socrata Data Management API, see the [Data Management API documentation](https://socratapublishing.docs.apiary.io/#)
+
 ## Build
 
 Compilation can be done using


### PR DESCRIPTION
Adding a brief note in the README about the difference in using the Socrata Open Data API (SODA) and the Socrata Data Management API to write to Socrata datasets. Includes a link to the Data Management API documentation. This is to help prevent confusion when automating data updates to Socrata that should make use of transforms applied on the platform during ingress. 