### PR TITLE
changed deleteRow method to use Upsert and added a helper class (Payl…

### DIFF
--- a/SODA/Utilities/PayloadBuilder.cs
+++ b/SODA/Utilities/PayloadBuilder.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SODA.Utilities
+{
+    /// <summary>
+    /// Helper class for constructing payload for post requests
+    /// </summary>
+    class PayloadBuilder
+    {
+        /// <summary>
+        /// Construct JSON payload to delete a single row using Upsert
+        /// </summary>
+        /// <param name="idFieldName">The name of the unique id field for the resource.</param>
+        /// <param name="rowId">The identifier of the row to be deleted.</param>
+        /// <returns>A json array string for submitting to the Upsert method</returns>
+        public static string GetDeletePayload(string IdFieldName,string rowId)
+        {
+           return $"[{{\"{IdFieldName}\": \"{rowId}\",\":deleted\": true }}]";
+        }
+
+        /// <summary>
+        /// Construct JSON payload to delete multiple rows using Upsert
+        /// </summary>
+        /// <param name="idFieldName">The name of the unique id field for the resource.</param>
+        /// <param name="rowIds">List of row identifiers to be deleted.</param>
+        /// <returns>A json array string for submitting to the Upsert method</returns>
+        public static string  GetDeletePayload(string idFieldName, List<string> rowIds)
+        {
+            string jsonPayload = "[";
+            foreach (var rowId in rowIds)
+            {
+                jsonPayload = $"{jsonPayload}{{\"{idFieldName}\": \"{rowId}\",\":deleted\": true }},";
+            }
+
+            jsonPayload = jsonPayload.TrimEnd(',');
+            return $"{jsonPayload}]";
+        }
+    }
+}


### PR DESCRIPTION
I modified the existing deleterow method to basically redirect to the sodaclient.Upsert method.  It still takes the same parameters and returns a SodaResult.
I added another DeleteRow method that takes a list if RowId's so can do a bulk delete now.  I called it DeleteRow also, to keep the changes to a minimum, not sure if better to call it DeleteRows?
I also added a helper class into Utilities "Payloadbuilder.cs" which just takes the RowId('s) and constructs into the required json format.
I didnt add any tests, not sure if any needed, and also i'm not very familiar with test frameworks.
I wrote the same logic into my application and has been working fine.  See what you think
Thanks
Mick