### PR TITLE
Fix resource URI generation

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,9 @@
+### New in 0.10.3 (Released 2022/05/04)
+
+Bug fixes
+
+-  Fix resource URI generation.
+
 ### New in 0.10.2 (Released 2022/04/18)
 
 New features

--- a/SODA.Tests/SodaUriTests.cs
+++ b/SODA.Tests/SodaUriTests.cs
@@ -177,13 +177,13 @@ namespace SODA.Tests
         public void ForResourceAPI_With_Valid_Arguments_Creates_ResourceAPI_Uri()
         {
             var uri = SodaUri.ForResourceAPI(StringMocks.Host, StringMocks.ResourceId);
-            StringAssert.AreEqualIgnoringCase(String.Format("/resource/{0}", StringMocks.ResourceId), uri.LocalPath);
+            StringAssert.AreEqualIgnoringCase(String.Format("/resource/{0}.json", StringMocks.ResourceId), uri.LocalPath);
 
             uri = null;
             string rowId = "rowId";
 
             uri = SodaUri.ForResourceAPI(StringMocks.Host, StringMocks.ResourceId, rowId);
-            StringAssert.AreEqualIgnoringCase(String.Format("/resource/{0}/{1}", StringMocks.ResourceId, rowId), uri.LocalPath);
+            StringAssert.AreEqualIgnoringCase(String.Format("/resource/{0}/{1}.json", StringMocks.ResourceId, rowId), uri.LocalPath);
         }
 
         [TestCase(StringMocks.NullInput)]

--- a/SODA/SODA.csproj
+++ b/SODA/SODA.csproj
@@ -8,7 +8,8 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>CSM.SodaDotNet</PackageId>
     <PackageTags>API OpenData Socrata SODA</PackageTags>
-    <Version>0.10.2</Version>
+    <Version>0.10.3</Version>
+    <Copyright>Copyright 2022 City of Santa Monica, CA</Copyright>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SODA/Utilities/SodaUri.cs
+++ b/SODA/Utilities/SodaUri.cs
@@ -117,7 +117,7 @@ namespace SODA.Utilities
                 url = String.Format("{0}/{1}", url, rowId);
             }
 
-            return new Uri(url);
+            return new Uri(url + ".json");
         }
 
         /// <summary>

--- a/Utilities/Utilities.csproj
+++ b/Utilities/Utilities.csproj
@@ -8,6 +8,8 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>CSM.SodaDotNet.Utilities</PackageId>
     <PackageTags>EWS Excel SODA</PackageTags>
+    <Version>0.10.3</Version>
+    <Copyright>Copyright 2022 City of Santa Monica, CA</Copyright>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fix Uri generation for resource upsert by appending ".json".  Without the JSON extension, receive HTTP 406 response after Upsert call.  Determine this review Socrata API ([https://dev.socrata.com/docs/row-identifiers.html](https://dev.socrata.com/docs/row-identifiers.html)).

Checked against several 4x4s and without the JSON extension, redirects to dataset about page.  With the JSON extension, receive data in JSON format.  Tested this on an ETL and verify successful response.